### PR TITLE
Added support to load actor and view positions with relative rotation.

### DIFF
--- a/ConceptMatrix/Resx/UIStringsContent.Designer.cs
+++ b/ConceptMatrix/Resx/UIStringsContent.Designer.cs
@@ -679,6 +679,7 @@ namespace ConceptMatrix.Resx {
         
         /// <summary>
         ///   Looks up a localized string similar to Load camera settings from file.
+        ///• Hold ALT to rotate Cam Angle X relative to the target.
         ///• Try jiggling the camera or loading again if the camera is blocked by an object and didn&apos;t restore completely..
         /// </summary>
         public static string CamSettingsLoadToolTip {
@@ -1446,7 +1447,8 @@ namespace ConceptMatrix.Resx {
         
         /// <summary>
         ///   Looks up a localized string similar to Load GPose View position from file.
-        ///• Hold CTRL when clicking this to load as an offset from the current actor position.
+        ///• Hold CTRL to load relative to the current actor position.
+        ///• Hold ALT to load and rotate relative to current actor position &amp; rotation.
         ///• You can load saved actor positionss to jump GPose View actor to that position..
         /// </summary>
         public static string GposeViewSettingsLoadToolTip {
@@ -2433,7 +2435,8 @@ namespace ConceptMatrix.Resx {
         
         /// <summary>
         ///   Looks up a localized string similar to Load actor position from file.
-        ///• Hold CTRL when clicking this to load as an offset from the current GPose View.
+        ///• Hold CTRL to load relative to current GPose View.
+        ///• Hold ALT to load and rotate relative to current GPose View &amp; cam angle.
         ///• You can load saved GPose View positions to jump an actor to that position.
         ///• Visible position is affected by emote animations! Use the same neutral emote when loading and saving for best results..
         /// </summary>

--- a/ConceptMatrix/Resx/UIStringsContent.resx
+++ b/ConceptMatrix/Resx/UIStringsContent.resx
@@ -328,6 +328,7 @@
   </data>
   <data name="CamSettingsLoadToolTip" xml:space="preserve">
     <value>Load camera settings from file.
+• Hold ALT to rotate Cam Angle X relative to the target.
 • Try jiggling the camera or loading again if the camera is blocked by an object and didn't restore completely.</value>
   </data>
   <data name="CamSettingsSaveToolTip" xml:space="preserve">
@@ -597,7 +598,8 @@
   </data>
   <data name="GposeViewSettingsLoadToolTip" xml:space="preserve">
     <value>Load GPose View position from file.
-• Hold CTRL when clicking this to load as an offset from the current actor position.
+• Hold CTRL to load relative to the current actor position.
+• Hold ALT to load and rotate relative to current actor position &amp; rotation.
 • You can load saved actor positionss to jump GPose View actor to that position.</value>
   </data>
   <data name="GposeViewSettingsSaveToolTip" xml:space="preserve">
@@ -936,7 +938,8 @@
   </data>
   <data name="PosSettingsLoadToolTip" xml:space="preserve">
     <value>Load actor position from file.
-• Hold CTRL when clicking this to load as an offset from the current GPose View.
+• Hold CTRL to load relative to current GPose View.
+• Hold ALT to load and rotate relative to current GPose View &amp; cam angle.
 • You can load saved GPose View positions to jump an actor to that position.
 • Visible position is affected by emote animations! Use the same neutral emote when loading and saving for best results.</value>
   </data>

--- a/ConceptMatrix/Utility/SaveSettings.cs
+++ b/ConceptMatrix/Utility/SaveSettings.cs
@@ -63,6 +63,15 @@ namespace ConceptMatrix.Utility
             public float CamAngleY { get; set; } = 0;
             public float CamPanX { get; set; } = 0;
             public float CamPanY { get; set; } = 0;
+
+            // Used to rotate Camera Angle X relative to Actor rotation
+            public float TargetRotation { get; set; } = 0;
+
+            // These are to help detect user errors loading things relative
+            // to the wrong target.
+            public string TargetRotationName { get; set; } = "None";
+            public int TargetRotationRace { get; set; } = 0;
+            public int TargetRotationClan { get; set; } = 0;
         }
 
         // Use the same type for character position and gpose view so
@@ -75,9 +84,21 @@ namespace ConceptMatrix.Utility
             public float Y { get; set; } = 0;
             public float Z { get; set; } = 0;
 
-            public float OffsetFromViewX { get; set; } = float.NaN;
-            public float OffsetFromViewY { get; set; } = float.NaN;
-            public float OffsetFromViewZ { get; set; } = float.NaN;
+            public float OffsetFromViewX { get; set; } = 0;
+            public float OffsetFromViewY { get; set; } = 0;
+            public float OffsetFromViewZ { get; set; } = 0;
+            // Used to rotate Actor relative to camera rotation
+            public float OffsetFromCamX { get; set; } = 0;
+
+            // Used to rotate GPose View position relative to Actor rotation
+            public float TargetRotation { get; set; } = 0;
+
+            // These are to help detect user errors loading things relative
+            // to the wrong target.
+            public string TargetRotationName { get; set; } = "None";
+            public int TargetRotationRace { get; set; } = 0;
+            public int TargetRotationClan { get; set; } = 0;
+
 
             public float Rotation1{ get; set; } = float.NaN;
             public float Rotation2 { get; set; } = float.NaN;


### PR DESCRIPTION
Hold ALT when clicking load buttons to load relative rotations. For example you can load the GPose View and Camera settings relative to your character's facing direction. Or you can load multiple actors with corrected rotation relative to the current view.