### PR TITLE
Remove extraneous check preventing update of internal rotation variables.

### DIFF
--- a/ConceptMatrix/ViewModel/CharacterDetailsViewModel.cs
+++ b/ConceptMatrix/ViewModel/CharacterDetailsViewModel.cs
@@ -557,7 +557,12 @@ namespace ConceptMatrix.ViewModel
 
                 // Reading rotation values.
                 #region Actor Rotation
-                if (!CharacterDetails.RotateFreeze && !CharacterDetails.BoneEditMode)
+                // TBD: lilly removed this extra check because it was causing the rotation values
+                //      to be wrong vs what the game shows in some cases. This caused annoying GUI
+                //      behavior and messed up the relative rotation code.
+                //
+                //      Unclear what this check was intended for.
+                if (!CharacterDetails.RotateFreeze /* && !CharacterDetails.BoneEditMode */)
                 {
                     byte[] bytearray = m.readBytes(GAS(baseAddr, c.Body.Base, c.Body.Position.Rotation), 16);
                     CharacterDetails.Rotation.value = BitConverter.ToSingle(bytearray, 0);

--- a/ConceptMatrix/Views/CharacterDetailsView3.xaml.cs
+++ b/ConceptMatrix/Views/CharacterDetailsView3.xaml.cs
@@ -1316,7 +1316,10 @@ namespace ConceptMatrix.Views
 
                 var radians = (euler_rot.Y - settings.TargetRotation) * (Math.PI * 2) / 360;
 
-                CharacterDetails.CamAngleX.value = (float) (settings.CamAngleX + radians);
+                radians += settings.CamAngleX;
+                if (radians > Math.PI) radians -= 2 * Math.PI;
+
+                CharacterDetails.CamAngleX.value = (float) radians;
             } 
             else
             {


### PR DESCRIPTION
This was making bad things happen like the GUI would show "current" values that are a lie, so when you freeze and change by 0.1 them the rotation jumps randomly. The relative rotation stuff was broken due to the inaccuracy as well.