### PR TITLE
fix half size problem for Chinese characters

### DIFF
--- a/ConceptMatrix/Utility/Memory.cs
+++ b/ConceptMatrix/Utility/Memory.cs
@@ -1051,7 +1051,7 @@ namespace ConceptMatrix.Utility
             {
                 memory = new byte[write.Length];
                 memory = System.Text.Encoding.UTF8.GetBytes(write);
-                size = write.Length;
+                size = memory.Length;
             }
 #if DEBUG
             StackTrace stackTrace = new StackTrace(true);


### PR DESCRIPTION
Otherwise only half of the memory will be updated if the string is in Chinese characters.